### PR TITLE
expose number of players and test

### DIFF
--- a/shamir.go
+++ b/shamir.go
@@ -251,6 +251,12 @@ func unmarshalToIndices(dst *[]secp256k1.Secp256k1N, r io.Reader, m int) (int, e
 	return m, nil
 }
 
+// N returns the number of players associated with this sharer instance. This
+// is equal to the the number of indices it was constructed with.
+func (sharer *Sharer) N() int {
+	return len(sharer.indices)
+}
+
 // NewSharer constructs a new Sharer object from the given set of indices.
 func NewSharer(indices []secp256k1.Secp256k1N) Sharer {
 	copiedIndices := make([]secp256k1.Secp256k1N, len(indices))
@@ -360,6 +366,12 @@ func (r *Reconstructor) Unmarshal(reader io.Reader, m int) (int, error) {
 	*r = NewReconstructor(indices)
 
 	return m, nil
+}
+
+// N returns the number of players associated with this reconstructor instance.
+// This is equal to the number of indices it was constructed with.
+func (r *Reconstructor) N() int {
+	return len(r.indices)
 }
 
 // NewReconstructor returns a new Reconstructor instance for the given indices.

--- a/shamir_test.go
+++ b/shamir_test.go
@@ -495,6 +495,14 @@ var _ = Describe("Shamir Secret Sharing", func() {
 		})
 
 		//
+		// Miscellaneous Tests
+		//
+
+		It("should correctly report the number of indices", func() {
+			Expect(sharer.N()).To(Equal(n))
+		})
+
+		//
 		// Marshaling
 		//
 
@@ -724,6 +732,14 @@ var _ = Describe("Shamir Secret Sharing", func() {
 				_, err = reconstructor.CheckedOpen(shares[:highK], k)
 				Expect(err).ToNot(HaveOccurred())
 			}
+		})
+
+		//
+		// Miscellaneous Tests
+		//
+
+		It("should correctly report the number of indices", func() {
+			Expect(reconstructor.N()).To(Equal(n))
 		})
 
 		//

--- a/vss.go
+++ b/vss.go
@@ -456,6 +456,12 @@ func (s *VSSharer) Unmarshal(r io.Reader, m int) (int, error) {
 	return m, nil
 }
 
+// N returns the number of players associated with this VSSharer instance. This
+// is equal to the number of indices it was constructed with.
+func (s *VSSharer) N() int {
+	return s.sharer.N()
+}
+
 // NewVSSharer constructs a new VSSharer from the given set of indices.
 func NewVSSharer(indices []secp256k1.Secp256k1N, h curve.Point) VSSharer {
 	sharer := NewSharer(indices)

--- a/vss_test.go
+++ b/vss_test.go
@@ -1040,6 +1040,10 @@ var _ = Describe("Verifiable secret sharing", func() {
 					Expect(rem).To(Equal(max - vssharer.SizeHint() + h.SizeHint()))
 				}
 			})
+
+			It("should correctly report the number of indices", func() {
+				Expect(vssharer.N()).To(Equal(n))
+			})
 		})
 
 		Context("Unmarshalling errors", func() {


### PR DESCRIPTION
This PR allows users of structs that have an implicit number of players for a given instance to be able to access this number.