### PR TITLE
Marshalling for new types

### DIFF
--- a/eea/eea.go
+++ b/eea/eea.go
@@ -1,6 +1,9 @@
 package eea
 
 import (
+	"math/rand"
+	"reflect"
+
 	"github.com/renproject/shamir/poly"
 )
 
@@ -85,4 +88,102 @@ func (eea *Stepper) Step() bool {
 	eea.tNext.Set(eea.r)
 
 	return eea.rNext.IsZero()
+}
+
+// Generate implements the quick.Generator interface.
+func (eea Stepper) Generate(rand *rand.Rand, size int) reflect.Value {
+	size = size / 8
+	rPrev := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	rNext := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	sPrev := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	sNext := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	tPrev := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	tNext := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	q := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	r := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	stepper := Stepper{
+		rPrev: rPrev, rNext: rNext,
+		sPrev: sPrev, sNext: sNext,
+		tPrev: tPrev, tNext: tNext,
+		q: q, r: r,
+	}
+	return reflect.ValueOf(stepper)
+}
+
+// SizeHint implements the surge.SizeHinter interface.
+func (eea Stepper) SizeHint() int {
+	return eea.rNext.SizeHint() +
+		eea.rPrev.SizeHint() +
+		eea.sNext.SizeHint() +
+		eea.sPrev.SizeHint() +
+		eea.tNext.SizeHint() +
+		eea.tPrev.SizeHint() +
+		eea.q.SizeHint() +
+		eea.r.SizeHint()
+}
+
+// Marshal implements the surge.Marshaler interface.
+func (eea Stepper) Marshal(buf []byte, rem int) ([]byte, int, error) {
+	buf, rem, err := eea.rNext.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.rPrev.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.sNext.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.sPrev.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.tNext.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.tPrev.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.q.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	return eea.r.Marshal(buf, rem)
+}
+
+// Unmarshal implements the surge.Unmarshaler interface.
+func (eea *Stepper) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	buf, rem, err := eea.rNext.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.rPrev.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.sNext.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.sPrev.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.tNext.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.tPrev.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = eea.q.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	return eea.r.Unmarshal(buf, rem)
 }

--- a/eea/marshal_test.go
+++ b/eea/marshal_test.go
@@ -1,0 +1,59 @@
+package eea_test
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/renproject/surge/surgeutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/renproject/shamir/eea"
+)
+
+var _ = Describe("Surge marshalling", func() {
+	trials := 100
+	t := reflect.TypeOf(Stepper{})
+
+	Context(fmt.Sprintf("surge marshalling and unmarshalling for %v", t), func() {
+		It("should be the same after marshalling and unmarshalling", func() {
+			for i := 0; i < trials; i++ {
+				Expect(surgeutil.MarshalUnmarshalCheck(t)).To(Succeed())
+			}
+		})
+
+		It("should not panic when fuzzing", func() {
+			for i := 0; i < trials; i++ {
+				Expect(func() { surgeutil.Fuzz(t) }).ToNot(Panic())
+			}
+		})
+
+		Context("marshalling", func() {
+			It("should return an error when the buffer is too small", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.MarshalBufTooSmall(t)).To(Succeed())
+				}
+			})
+
+			It("should return an error when the memory quota is too small", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.MarshalRemTooSmall(t)).To(Succeed())
+				}
+			})
+		})
+
+		Context("unmarshalling", func() {
+			It("should return an error when the buffer is too small", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.UnmarshalBufTooSmall(t)).To(Succeed())
+				}
+			})
+
+			It("should return an error when the memory quota is too small", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.UnmarshalRemTooSmall(t)).To(Succeed())
+				}
+			})
+		})
+	})
+})

--- a/poly/interpolator.go
+++ b/poly/interpolator.go
@@ -1,7 +1,11 @@
 package poly
 
 import (
+	"math/rand"
+	"reflect"
+
 	"github.com/renproject/secp256k1"
+	"github.com/renproject/surge"
 )
 
 // Interpolator can perform polynomial interpolation. That is, the act of
@@ -80,4 +84,31 @@ func (interp *Interpolator) Interpolate(values []secp256k1.Fn, poly *Poly) {
 	for i := 1; i < len(interp.basis); i++ {
 		poly.AddScaled(*poly, interp.basis[i], values[i])
 	}
+}
+
+// Generate implements the quick.Generator interface.
+func (interp Interpolator) Generate(_ *rand.Rand, size int) reflect.Value {
+	n := rand.Intn(size + 1)
+	m := size / (n + 1)
+	basis := make([]Poly, n)
+	for i := range basis {
+		basis[i] = make(Poly, m)
+		for j := range basis[i] {
+			basis[i][j] = secp256k1.RandomFn()
+		}
+	}
+	return reflect.ValueOf(Interpolator{basis: basis})
+}
+
+// SizeHint implements the surge.SizeHinter interface.
+func (interp Interpolator) SizeHint() int { return surge.SizeHint(interp.basis) }
+
+// Marshal implements the surge.Marshaler interface.
+func (interp Interpolator) Marshal(buf []byte, rem int) ([]byte, int, error) {
+	return surge.Marshal(interp.basis, buf, rem)
+}
+
+// Unmarshal implements the surge.Unmarshaler interface.
+func (interp *Interpolator) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	return surge.Unmarshal(&interp.basis, buf, rem)
 }

--- a/poly/marshal_test.go
+++ b/poly/marshal_test.go
@@ -1,0 +1,66 @@
+package poly_test
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/renproject/surge/surgeutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/renproject/shamir/poly"
+)
+
+var _ = Describe("Surge marshalling", func() {
+	trials := 100
+	types := []reflect.Type{
+		reflect.TypeOf(Poly{}),
+		reflect.TypeOf(Interpolator{}),
+	}
+
+	for _, t := range types {
+		t := t
+
+		Context(fmt.Sprintf("surge marshalling and unmarshalling for %v", t), func() {
+			It("should be the same after marshalling and unmarshalling", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.MarshalUnmarshalCheck(t)).To(Succeed())
+				}
+			})
+
+			It("should not panic when fuzzing", func() {
+				for i := 0; i < trials; i++ {
+					Expect(func() { surgeutil.Fuzz(t) }).ToNot(Panic())
+				}
+			})
+
+			Context("marshalling", func() {
+				It("should return an error when the buffer is too small", func() {
+					for i := 0; i < trials; i++ {
+						Expect(surgeutil.MarshalBufTooSmall(t)).To(Succeed())
+					}
+				})
+
+				It("should return an error when the memory quota is too small", func() {
+					for i := 0; i < trials; i++ {
+						Expect(surgeutil.MarshalRemTooSmall(t)).To(Succeed())
+					}
+				})
+			})
+
+			Context("unmarshalling", func() {
+				It("should return an error when the buffer is too small", func() {
+					for i := 0; i < trials; i++ {
+						Expect(surgeutil.UnmarshalBufTooSmall(t)).To(Succeed())
+					}
+				})
+
+				It("should return an error when the memory quota is too small", func() {
+					for i := 0; i < trials; i++ {
+						Expect(surgeutil.UnmarshalRemTooSmall(t)).To(Succeed())
+					}
+				})
+			})
+		})
+	}
+})

--- a/poly/poly.go
+++ b/poly/poly.go
@@ -2,9 +2,12 @@ package poly
 
 import (
 	"fmt"
+	"math/rand"
+	"reflect"
 
 	"github.com/renproject/secp256k1"
 	"github.com/renproject/shamir/shamirutil"
+	"github.com/renproject/surge"
 )
 
 // Poly represents a polynomial in the field defined by the elliptic curve
@@ -451,4 +454,58 @@ func Divide(a, b Poly, q, r *Poly) {
 	if len(*r) == 0 {
 		r.Zero()
 	}
+}
+
+// Generate implements the quick.Generator interface.
+func (p Poly) Generate(_ *rand.Rand, size int) reflect.Value {
+	poly := make(Poly, size)
+	for i := range poly {
+		poly[i] = secp256k1.RandomFn()
+	}
+	return reflect.ValueOf(poly)
+}
+
+// SizeHint implements the surge.SizeHinter interface.
+func (p Poly) SizeHint() int {
+	return surge.SizeHintU32 + secp256k1.FnSizeMarshalled*len(p)
+}
+
+// Marshal implements the surge.Marshaler interface.
+func (p Poly) Marshal(buf []byte, rem int) ([]byte, int, error) {
+	buf, rem, err := surge.MarshalLen(uint32(len(p)), buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	for _, c := range p {
+		buf, rem, err = c.Marshal(buf, rem)
+		if err != nil {
+			return buf, rem, err
+		}
+	}
+	return buf, rem, nil
+}
+
+// Unmarshal implements the surge.Unmarshaler interface.
+func (p *Poly) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var l uint32
+	buf, rem, err := surge.UnmarshalLen(&l, secp256k1.FnSize, buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if l == 0 {
+		*p = []secp256k1.Fn{}
+		return buf, rem, nil
+	}
+	if len(*p) < int(l) {
+		*p = make(Poly, l)
+	} else {
+		*p = (*p)[:l]
+	}
+	for i := range *p {
+		buf, rem, err = (*p)[i].Unmarshal(buf, rem)
+		if err != nil {
+			return buf, rem, err
+		}
+	}
+	return buf, rem, nil
 }

--- a/rs/marshal_test.go
+++ b/rs/marshal_test.go
@@ -1,0 +1,59 @@
+package rs_test
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/renproject/surge/surgeutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/renproject/shamir/rs"
+)
+
+var _ = Describe("Surge marshalling", func() {
+	trials := 10
+	t := reflect.TypeOf(Decoder{})
+
+	Context(fmt.Sprintf("surge marshalling and unmarshalling for %v", t), func() {
+		It("should be the same after marshalling and unmarshalling", func() {
+			for i := 0; i < trials; i++ {
+				Expect(surgeutil.MarshalUnmarshalCheck(t)).To(Succeed())
+			}
+		})
+
+		It("should not panic when fuzzing", func() {
+			for i := 0; i < trials; i++ {
+				Expect(func() { surgeutil.Fuzz(t) }).ToNot(Panic())
+			}
+		})
+
+		Context("marshalling", func() {
+			It("should return an error when the buffer is too small", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.MarshalBufTooSmall(t)).To(Succeed())
+				}
+			})
+
+			It("should return an error when the memory quota is too small", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.MarshalRemTooSmall(t)).To(Succeed())
+				}
+			})
+		})
+
+		Context("unmarshalling", func() {
+			It("should return an error when the buffer is too small", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.UnmarshalBufTooSmall(t)).To(Succeed())
+				}
+			})
+
+			It("should return an error when the memory quota is too small", func() {
+				for i := 0; i < trials; i++ {
+					Expect(surgeutil.UnmarshalRemTooSmall(t)).To(Succeed())
+				}
+			})
+		})
+	})
+})

--- a/rs/rs.go
+++ b/rs/rs.go
@@ -1,9 +1,13 @@
 package rs
 
 import (
+	"math/rand"
+	"reflect"
+
 	"github.com/renproject/secp256k1"
 	"github.com/renproject/shamir/eea"
 	"github.com/renproject/shamir/poly"
+	"github.com/renproject/surge"
 )
 
 // Decoder can do Reed-Solomon decoding on given codewords. RS code words are
@@ -131,4 +135,146 @@ func (dec *Decoder) ErrorIndices() []secp256k1.Fn {
 	}
 
 	return dec.errors
+}
+
+// Generate implements the quick.Generator interface.
+func (dec Decoder) Generate(rand *rand.Rand, size int) reflect.Value {
+	n := rand.Int31()
+	k := rand.Int31()
+	indices := make([]secp256k1.Fn, size/10)
+	for i := range indices {
+		indices[i] = secp256k1.RandomFn()
+	}
+	interpolator := poly.Interpolator{}.Generate(rand, size).Interface().(poly.Interpolator)
+	eea := eea.Stepper{}.Generate(rand, size).Interface().(eea.Stepper)
+	g0 := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	interpPoly := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	f1 := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	r := poly.Poly{}.Generate(rand, size).Interface().(poly.Poly)
+	errors := make([]secp256k1.Fn, size/10)
+	for i := range errors {
+		errors[i] = secp256k1.RandomFn()
+	}
+	errorsComputed := rand.Int()&1 == 1
+	decoder := Decoder{
+		n: int(n), k: int(k),
+		indices:      indices,
+		interpolator: interpolator,
+		eea:          eea,
+
+		g0:         g0,
+		interpPoly: interpPoly,
+		f1:         f1, r: r,
+		errors:         errors,
+		errorsComputed: errorsComputed,
+	}
+	return reflect.ValueOf(decoder)
+}
+
+// SizeHint implements the surge.SizeHinter interface.
+func (dec Decoder) SizeHint() int {
+	return surge.SizeHintI32 +
+		surge.SizeHintI32 +
+		surge.SizeHint(dec.indices) +
+		dec.interpolator.SizeHint() +
+		dec.eea.SizeHint() +
+		dec.g0.SizeHint() +
+		dec.interpPoly.SizeHint() +
+		dec.f1.SizeHint() +
+		dec.r.SizeHint() +
+		surge.SizeHint(dec.errors) +
+		surge.SizeHint(dec.errorsComputed)
+}
+
+// Marshal implements the surge.Marshaler interface.
+func (dec Decoder) Marshal(buf []byte, rem int) ([]byte, int, error) {
+	buf, rem, err := surge.MarshalI32(int32(dec.n), buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = surge.MarshalI32(int32(dec.k), buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = surge.Marshal(dec.indices, buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.interpolator.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.eea.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.g0.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.interpPoly.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.f1.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.r.Marshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = surge.Marshal(dec.errors, buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	return surge.Marshal(dec.errorsComputed, buf, rem)
+}
+
+// Unmarshal implements the surge.Unmarshaler interface.
+func (dec *Decoder) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var tmp int32
+	buf, rem, err := surge.UnmarshalI32(&tmp, buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	dec.n = int(tmp)
+	buf, rem, err = surge.UnmarshalI32(&tmp, buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	dec.k = int(tmp)
+	buf, rem, err = surge.Unmarshal(&dec.indices, buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.interpolator.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.eea.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.g0.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.interpPoly.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.f1.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = dec.r.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	buf, rem, err = surge.Unmarshal(&dec.errors, buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	return surge.Unmarshal(&dec.errorsComputed, buf, rem)
 }

--- a/shamir.go
+++ b/shamir.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ShareSize is the number of bytes in a share.
-const ShareSize = 2 * secp256k1.FnSize
+const ShareSize = 2 * secp256k1.FnSizeMarshalled
 
 // Shares represents a slice of Shamir shares
 type Shares []Share
@@ -165,7 +165,9 @@ func (sharer Sharer) Generate(rand *rand.Rand, size int) reflect.Value {
 }
 
 // SizeHint implements the surge.SizeHinter interface.
-func (sharer Sharer) SizeHint() int { return surge.SizeHintU32 + len(sharer.indices)*secp256k1.FnSize }
+func (sharer Sharer) SizeHint() int {
+	return surge.SizeHintU32 + len(sharer.indices)*secp256k1.FnSizeMarshalled
+}
 
 // Marshal implements the surge.Marshaler interface.
 func (sharer Sharer) Marshal(buf []byte, rem int) ([]byte, int, error) {
@@ -290,7 +292,9 @@ func (r Reconstructor) Generate(rand *rand.Rand, size int) reflect.Value {
 }
 
 // SizeHint implements the surge.SizeHinter interface.
-func (r Reconstructor) SizeHint() int { return surge.SizeHintU32 + len(r.indices)*secp256k1.FnSize }
+func (r Reconstructor) SizeHint() int {
+	return surge.SizeHintU32 + len(r.indices)*secp256k1.FnSizeMarshalled
+}
 
 // Marshal implements the surge.Marshaler interface.
 func (r Reconstructor) Marshal(buf []byte, rem int) ([]byte, int, error) {

--- a/shamir_test.go
+++ b/shamir_test.go
@@ -317,7 +317,7 @@ var _ = Describe("Shamir Secret Sharing", func() {
 		// Marshaling
 		//
 
-		var bs [4 + n*secp256k1.FnSize]byte
+		var bs [4 + n*secp256k1.FnSizeMarshalled]byte
 
 		It("should function correctly after marshalling and unmarshalling", func() {
 			trials = 10
@@ -381,7 +381,7 @@ var _ = Describe("Shamir Secret Sharing", func() {
 		var reconstructor Reconstructor
 		var k int
 		var secret secp256k1.Fn
-		var bs [4 + n*secp256k1.FnSize]byte
+		var bs [4 + n*secp256k1.FnSizeMarshalled]byte
 
 		BeforeEach(func() {
 			indices = RandomIndices(n)
@@ -508,11 +508,6 @@ var _ = Describe("Shamir Secret Sharing", func() {
 	//
 
 	Context("Constants", func() {
-		Specify("secp256k1.FnSize should have correct value", func() {
-			x := secp256k1.Fn{}
-			Expect(secp256k1.FnSize).To(Equal(x.SizeHint()))
-		})
-
 		Specify("ShareSize should have correct value", func() {
 			share := Share{}
 			Expect(ShareSize).To(Equal(share.SizeHint()))

--- a/vss.go
+++ b/vss.go
@@ -9,7 +9,7 @@ import (
 )
 
 // VShareSize is the size of a verifiable share in bytes.
-const VShareSize = ShareSize + secp256k1.FnSize
+const VShareSize = ShareSize + secp256k1.FnSizeMarshalled
 
 // VerifiableShares is a alias for a slice of VerifiableShare(s).
 type VerifiableShares []VerifiableShare


### PR DESCRIPTION
The recently added types `Poly`, `Interpolator`, `Stepper` and `Decoder` don't have marshalling interfaces. This PR addresses this issue.